### PR TITLE
CRITICAL BUG FIX: Added variable definition in if/else case.

### DIFF
--- a/mobileVers/dashboard/views.py
+++ b/mobileVers/dashboard/views.py
@@ -905,6 +905,7 @@ def dashboardGetFoco(request):
         QProgramNumber = QProgramNumber - 1
         RECDisplayPending = "None"
         RECDisplayActive = ""
+        RECPendingDate = ""
         RECDisplay ="none"
     else:
         RECButtonText = "Quick Apply +"


### PR DESCRIPTION
This was causing anyone who had been enrolled in Recreation to get a '500 Server Error' on login.